### PR TITLE
[Fixed] Non-ASCII symbols not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ During normal operation, *Tail* will emit warnings and errors to the Sublime Tex
 
 ## Reporting bugs
 
-In order to make bug hunting easier, please ensure, that you always run the *latest* version of *Tail*. Apart from this, please ensure, that you've set *Tail* log level to maximum (`"log_level": "trace"` in user settings), in order to get all debugging information possible. Also please include the following information, when submitting an issue:
+In order to make bug hunting easier, please ensure, that you always run the *latest* version of *Tail*. Apart from this, please ensure, that you've set *Tail* log level to maximum (`"log_level": "trace"` in user settings), in order to get all debugging information possible. Also, please include the following information, when submitting an issue:
 
 * Operating system name (i.e. "Windows XP SP3", **not** "Windows")
 

--- a/packages/tail/source.py
+++ b/packages/tail/source.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, unicode_literals
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os
 import sys
 import threading
 import time
-from ..sublime_plugin_lib import compat
+
 from . import plugin
+from ..sublime_plugin_lib import compat
 
 # Registered Tail sources.
 TAIL_SOURCES = {}
@@ -152,7 +155,7 @@ class TailSourceUpdater(threading.Thread):
         """
 
         try:
-            with open(self.source.filepath) as fh:
+            with open(self.source.filepath, encoding='utf-8') as fh:
                 # Seek to end of file and wait for new lines.
                 fh.seek(0, 2)
 
@@ -162,7 +165,8 @@ class TailSourceUpdater(threading.Thread):
                         break
 
                     if line:
-                        self.source.add_line(TailSourceLine(self.source, line.rstrip('\r\n')))
+                        self.source.add_line(TailSourceLine(
+                            self.source, line.rstrip('\r\n')))
                     else:
                         # self.signal.wait(0.2)
                         self.stop_signal.wait(0.2)


### PR DESCRIPTION
(I'm sorry, you not have issue tracker, so I write here.)

### 1. Summary

SublimeTail gives [**Mojibake**](https://en.wikipedia.org/wiki/Mojibake), if I have Cyrillic symbols in my log.

### 2. Expected behavior

Correct displaying Cyrillic symbols.

### 3. Actual behavior

![Actual](http://i.imgur.com/LuYieJg.gif)

### 4. Steps to reproduce

The problem is reproduced for me in a version of Sublime Text without plugins and user settings.

I install SublimeTail from `devel` tree → I restart Sublime Text → I create file `test.md` in UTF-8 encoding → <kbd>Ctrl+Shift+P</kbd> → `Tail: Tail File In New View` → I print in `test.md`

    Sasha
    Великомученица!

In tab Tail: `test.md` I see

    Sasha
    Р’РµР»РёРєРѕРјСѓС‡РµРЅРёС†Р°!

### 5. Example in other apps

I have similar problem in other Sublime Text packages:

+ [**Code Presenter**](https://github.com/fwph/codepresenter/issues/5)
+ [**SendToSandbox**](https://github.com/DavidGerva/SendToSandbox-SublimePlugin/issues/1)
+ [**HackerTyper**](https://github.com/rexxars/sublime-hacker-typer/issues/4)

Developer of Code Presenter [**fixed**](https://github.com/fwph/codepresenter/commit/a81de2efa0210aa4730dd789719db2faed0b8c1f) similar bug.

### 6. Environment

**Operating system and version:**
Windows 32-bit 10.0.14393
**Sublime Text:**
Build 3126


Thanks.